### PR TITLE
#11 mods.tomlの書式ミス

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -26,7 +26,7 @@ sourceSets {
 
 version = "${minecraft_version}-${mod_version}-forge"
 group = 'mekanism'
-archivesBaseName = 'Stellar'
+archivesBaseName = 'MekanismStellar'
 
 // Mojang ships Java 17 to end users in 1.18+, so your mod should target Java 17.
 java.toolchain.languageVersion = JavaLanguageVersion.of("${java_version}")

--- a/src/main/resources/META-INF/mods.toml
+++ b/src/main/resources/META-INF/mods.toml
@@ -15,5 +15,6 @@ versionRange = "${mekanism_version}"
 side = "BOTH"
 [[dependencies.stellar]]
 modId = "mekanismgenerators"
+mandatory = true
 versionRange = "${mekanism_version}"
 side = "BOTH"


### PR DESCRIPTION
#11 mods.tomlのdependenciesでmandatoryを指定することが必須だった。